### PR TITLE
Fix query consistency and refresh dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
             "dependencies": {
                 "cors": "^2.8.6",
                 "couchbase": "4.7.0",
-                "express": "^4.22.1",
+                "express": "^4.22.2",
                 "swagger-ui-express": "^5.0.1",
-                "yaml": "^2.8.3"
+                "yaml": "^2.9.0"
             },
             "devDependencies": {
                 "@babel/cli": "^7.28.6",
@@ -30,9 +30,9 @@
                 "env-cmd": "^10.1.0",
                 "jest": "^29.7.0",
                 "nodemon": "^3.1.14",
-                "prettier": "^3.4.2",
+                "prettier": "^3.8.4",
                 "supertest": "^7.2.2",
-                "ts-jest": "^29.4.9",
+                "ts-jest": "^29.4.11",
                 "ts-node": "^10.9.2",
                 "typescript": "^5.9.3"
             }
@@ -83,13 +83,13 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -98,9 +98,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-            "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -108,21 +108,21 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-compilation-targets": "^7.28.6",
-                "@babel/helper-module-transforms": "^7.28.6",
-                "@babel/helpers": "^7.28.6",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/traverse": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -171,14 +171,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.29.1",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -201,14 +201,14 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-            "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.28.6",
-                "@babel/helper-validator-option": "^7.27.1",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -328,9 +328,9 @@
             "license": "MIT"
         },
         "node_modules/@babel/helper-globals": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -352,29 +352,29 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.28.6",
-                "@babel/helper-validator-identifier": "^7.28.5",
-                "@babel/traverse": "^7.28.6"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -397,9 +397,9 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-            "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+            "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -457,9 +457,9 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -467,9 +467,9 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -477,9 +477,9 @@
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -502,14 +502,14 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-            "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -549,13 +549,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.0"
+                "@babel/types": "^7.29.7"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -1324,16 +1324,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-            "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
+            "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.28.6",
-                "@babel/helper-plugin-utils": "^7.28.6",
-                "@babel/helper-validator-identifier": "^7.28.5",
-                "@babel/traverse": "^7.29.0"
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1932,33 +1932,33 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.28.6",
-                "@babel/parser": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -1989,14 +1989,14 @@
             "dev": true
         },
         "node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -4505,14 +4505,14 @@
             }
         },
         "node_modules/express": {
-            "version": "4.22.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-            "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+            "version": "4.22.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+            "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
             "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "~1.20.3",
+                "body-parser": "~1.20.5",
                 "content-disposition": "~0.5.4",
                 "content-type": "~1.0.4",
                 "cookie": "~0.7.1",
@@ -4531,7 +4531,7 @@
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "~0.1.12",
                 "proxy-addr": "~2.0.7",
-                "qs": "~6.14.0",
+                "qs": "~6.15.1",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
                 "send": "~0.19.0",
@@ -4548,21 +4548,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/express/node_modules/qs": {
-            "version": "6.14.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "side-channel": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/fast-json-stable-stringify": {
@@ -4656,17 +4641,17 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -5031,9 +5016,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -6837,9 +6822,9 @@
             }
         },
         "node_modules/nodemon/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7230,9 +7215,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-            "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+            "version": "3.8.4",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+            "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -7319,9 +7304,9 @@
             ]
         },
         "node_modules/qs": {
-            "version": "6.15.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+            "version": "6.15.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"
@@ -8184,9 +8169,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.13",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-            "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+            "version": "7.5.16",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/fs-minipass": "^4.0.0",
@@ -8263,9 +8248,9 @@
             }
         },
         "node_modules/ts-jest": {
-            "version": "29.4.9",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
-            "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
+            "version": "29.4.11",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+            "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8275,7 +8260,7 @@
                 "json5": "^2.2.3",
                 "lodash.memoize": "^4.1.2",
                 "make-error": "^1.3.6",
-                "semver": "^7.7.4",
+                "semver": "^7.8.0",
                 "type-fest": "^4.41.0",
                 "yargs-parser": "^21.1.1"
             },
@@ -8316,9 +8301,9 @@
             }
         },
         "node_modules/ts-jest/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+            "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -8801,9 +8786,9 @@
             "dev": true
         },
         "node_modules/yaml": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -26,17 +26,17 @@
         "env-cmd": "^10.1.0",
         "jest": "^29.7.0",
         "nodemon": "^3.1.14",
-        "prettier": "^3.4.2",
+        "prettier": "^3.8.4",
         "supertest": "^7.2.2",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
     },
     "dependencies": {
         "cors": "^2.8.6",
         "couchbase": "4.7.0",
-        "express": "^4.22.1",
+        "express": "^4.22.2",
         "swagger-ui-express": "^5.0.1",
-        "yaml": "^2.8.3"
+        "yaml": "^2.9.0"
     }
 }

--- a/src/controllers/airlineController.ts
+++ b/src/controllers/airlineController.ts
@@ -2,7 +2,7 @@ import { Airline } from '../models/airlineModels'
 import { Request, Response } from 'express'
 import { makeResponse } from '../shared/makeResponse'
 import { getDatabase } from '../../db/connection'
-import { GetResult, QueryResult } from 'couchbase'
+import { GetResult, QueryResult, QueryScanConsistency } from 'couchbase'
 
 const createAirline = async (req: Request, res: Response) => {
     let newAirline: Airline = {
@@ -59,6 +59,7 @@ const listAirlines = async (req: Request, res: Response) => {
             LIMIT: number
             OFFSET: number
         }
+        scanConsistency: QueryScanConsistency
     }
     let options: QueryOptions
     if (country !== '') {
@@ -76,6 +77,7 @@ const listAirlines = async (req: Request, res: Response) => {
         `
         options = {
             parameters: { COUNTRY: country, LIMIT: limit, OFFSET: offset },
+            scanConsistency: QueryScanConsistency.RequestPlus,
         }
     } else {
         query = `
@@ -90,7 +92,10 @@ const listAirlines = async (req: Request, res: Response) => {
           OFFSET $OFFSET;
         `
 
-        options = { parameters: { LIMIT: limit, OFFSET: offset } }
+        options = {
+            parameters: { LIMIT: limit, OFFSET: offset },
+            scanConsistency: QueryScanConsistency.RequestPlus,
+        }
     }
     await makeResponse(res, async () => {
         const results: QueryResult = await scope.query(query, options)
@@ -111,6 +116,7 @@ const listAirlinesToAirport = async (req: Request, res: Response) => {
             LIMIT: number
             OFFSET: number
         }
+        scanConsistency: QueryScanConsistency
     }
     let options: QueryOptions
     query = `
@@ -130,7 +136,10 @@ const listAirlinesToAirport = async (req: Request, res: Response) => {
           LIMIT $LIMIT
           OFFSET $OFFSET;
         `
-    options = { parameters: { AIRPORT: airport, LIMIT: limit, OFFSET: offset } }
+    options = {
+        parameters: { AIRPORT: airport, LIMIT: limit, OFFSET: offset },
+        scanConsistency: QueryScanConsistency.RequestPlus,
+    }
     await makeResponse(res, async () => {
         const results: QueryResult = await scope.query(query, options)
         return results['rows']

--- a/src/controllers/airlineController.ts
+++ b/src/controllers/airlineController.ts
@@ -2,7 +2,7 @@ import { Airline } from '../models/airlineModels'
 import { Request, Response } from 'express'
 import { makeResponse } from '../shared/makeResponse'
 import { getDatabase } from '../../db/connection'
-import { GetResult, QueryResult, QueryScanConsistency } from 'couchbase'
+import { GetResult, QueryOptions, QueryResult, QueryScanConsistency } from 'couchbase'
 
 const createAirline = async (req: Request, res: Response) => {
     let newAirline: Airline = {
@@ -53,14 +53,6 @@ const listAirlines = async (req: Request, res: Response) => {
     let limit = parseInt(req.query.limit as string, 10) || 10
     let offset = parseInt(req.query.offset as string, 10) || 0
     let query: string
-    type QueryOptions = {
-        parameters: {
-            COUNTRY?: string
-            LIMIT: number
-            OFFSET: number
-        }
-        scanConsistency: QueryScanConsistency
-    }
     let options: QueryOptions
     if (country !== '') {
         query = `
@@ -110,14 +102,6 @@ const listAirlinesToAirport = async (req: Request, res: Response) => {
     let limit = parseInt(req.query.limit as string, 10) || 10
     let offset = parseInt(req.query.offset as string, 10) || 0
     let query: string
-    type QueryOptions = {
-        parameters: {
-            AIRPORT?: string
-            LIMIT: number
-            OFFSET: number
-        }
-        scanConsistency: QueryScanConsistency
-    }
     let options: QueryOptions
     query = `
           SELECT air.callsign,

--- a/src/controllers/airportController.ts
+++ b/src/controllers/airportController.ts
@@ -2,7 +2,7 @@ import { Airport } from '../models/airportModels'
 import { Request, Response } from 'express'
 import { makeResponse } from '../shared/makeResponse'
 import { getDatabase } from '../../db/connection'
-import { GetResult, QueryResult } from 'couchbase'
+import { GetResult, QueryResult, QueryScanConsistency } from 'couchbase'
 
 const createAirport = async (req: Request, res: Response) => {
     let newairport: Airport = {
@@ -59,6 +59,7 @@ const listAirport = async (req: Request, res: Response) => {
             LIMIT: number
             OFFSET: number
         }
+        scanConsistency: QueryScanConsistency
     }
     let options: QueryOptions
     if (country !== '') {
@@ -78,6 +79,7 @@ const listAirport = async (req: Request, res: Response) => {
         `
         options = {
             parameters: { COUNTRY: country, LIMIT: limit, OFFSET: offset },
+            scanConsistency: QueryScanConsistency.RequestPlus,
         }
     } else {
         query = `
@@ -94,7 +96,10 @@ const listAirport = async (req: Request, res: Response) => {
       OFFSET $OFFSET;
         `
 
-        options = { parameters: { LIMIT: limit, OFFSET: offset } }
+        options = {
+            parameters: { LIMIT: limit, OFFSET: offset },
+            scanConsistency: QueryScanConsistency.RequestPlus,
+        }
     }
     await makeResponse(res, async () => {
         let results: QueryResult = await scope.query(query, options)
@@ -115,6 +120,7 @@ const ListDirectConnection = async (req: Request, res: Response) => {
             LIMIT: number
             OFFSET: number
         }
+        scanConsistency: QueryScanConsistency
     }
     let options: QueryOptions
     query = `
@@ -126,7 +132,10 @@ const ListDirectConnection = async (req: Request, res: Response) => {
       LIMIT $LIMIT
       OFFSET $OFFSET
         `
-    options = { parameters: { AIRPORT: airport, LIMIT: limit, OFFSET: offset } }
+    options = {
+        parameters: { AIRPORT: airport, LIMIT: limit, OFFSET: offset },
+        scanConsistency: QueryScanConsistency.RequestPlus,
+    }
     await makeResponse(res, async () => {
         let results: QueryResult = await scope.query(query, options)
         return results['rows']

--- a/src/controllers/airportController.ts
+++ b/src/controllers/airportController.ts
@@ -2,7 +2,7 @@ import { Airport } from '../models/airportModels'
 import { Request, Response } from 'express'
 import { makeResponse } from '../shared/makeResponse'
 import { getDatabase } from '../../db/connection'
-import { GetResult, QueryResult, QueryScanConsistency } from 'couchbase'
+import { GetResult, QueryOptions, QueryResult, QueryScanConsistency } from 'couchbase'
 
 const createAirport = async (req: Request, res: Response) => {
     let newairport: Airport = {
@@ -53,14 +53,6 @@ const listAirport = async (req: Request, res: Response) => {
     let limit = parseInt(req.query.limit as string, 10) || 10
     let offset = parseInt(req.query.offset as string, 10) || 0
     let query: string
-    type QueryOptions = {
-        parameters: {
-            COUNTRY?: string
-            LIMIT: number
-            OFFSET: number
-        }
-        scanConsistency: QueryScanConsistency
-    }
     let options: QueryOptions
     if (country !== '') {
         query = `
@@ -114,14 +106,6 @@ const ListDirectConnection = async (req: Request, res: Response) => {
     let limit = parseInt(req.query.limit as string, 10) || 10
     let offset = parseInt(req.query.offset as string, 10) || 0
     let query: string
-    type QueryOptions = {
-        parameters: {
-            AIRPORT?: string
-            LIMIT: number
-            OFFSET: number
-        }
-        scanConsistency: QueryScanConsistency
-    }
     let options: QueryOptions
     query = `
       SELECT DISTINCT route.destinationairport


### PR DESCRIPTION
## Summary
- fix the airport and airline query endpoints to use request-plus scan consistency so newly written docs are immediately visible to N1QL-backed quickstart flows
- refresh targeted npm dependencies (`express`, `prettier`, `ts-jest`, `yaml`) and update the lockfile with `npm audit fix`
- clear production audit findings while keeping the remaining dev-only Jest/Istanbul audit drift deferred because it needs a breaking toolchain change

## Verification
- `npm install`
- `npm test` *(baseline on `origin/main`: 3 list/query suites failed before the consistency fix)*
- `npm install express@^4.22.2 prettier@^3.8.4 ts-jest@^29.4.11 yaml@^2.9.0`
- `npm audit fix`
- `npm test`
- `npm start`
- `curl http://127.0.0.1:3100/api/v1/airport/list --get --data-urlencode country="United States" --data limit=2 --data offset=0`
- `curl http://127.0.0.1:3100/api/v1/airport/direct-connections --get --data airport=SFO --data limit=2 --data offset=0`
- `curl http://127.0.0.1:3100/api/v1/airline/to-airport --get --data airport=SFO --data limit=2 --data offset=0`

## Evidence
- `npm test` passes after the fix: 16 suites / 16 tests.
- Local walkthrough succeeded against the local `travel-sample` bucket, including airport listing, direct-connections lookup, airline-to-airport lookup, and the Swagger UI.
- Visual proof captured from the Swagger surface:
  - `tutorial-maintenance/runs/couchbase-examples__typescript-quickstart/2026-06-16T1848PDT/screenshots/swagger-ui.png`
  - `tutorial-maintenance/runs/couchbase-examples__typescript-quickstart/2026-06-16T1848PDT/walkthrough-swagger.webm`
- Supporting artifacts:
  - `tutorial-maintenance/runs/couchbase-examples__typescript-quickstart/2026-06-16T1848PDT/verification.md`
  - `tutorial-maintenance/runs/couchbase-examples__typescript-quickstart/2026-06-16T1848PDT/walkthrough-http.txt`
  - `tutorial-maintenance/runs/couchbase-examples__typescript-quickstart/2026-06-16T1848PDT/npm-test-post-audit-fix.log`

<details><summary>Walkthrough excerpt</summary>

```text
$ curl http://127.0.0.1:3100/api/v1/airport/list?country=United%20States&limit=2&offset=0
[{"airportname":"Aberdeen Regional Airport","city":"Aberdeen","country":"United States","faa":"ABR"}, ...]

$ curl http://127.0.0.1:3100/api/v1/airport/direct-connections?airport=SFO&limit=2&offset=0
[{"destinationairport":"ABQ"},{"destinationairport":"ACV"}]

$ curl http://127.0.0.1:3100/api/v1/airline/to-airport?airport=SFO&limit=2&offset=0
[{"callsign":"AIRFRANS","country":"France","iata":"AF","icao":"AFR","name":"Air France"}, ...]
```

</details>

## Notes
- `tutorial-maintenance/tutorials.json` still says this repo's GitHub Actions runtime is Node 20.x, but the repo itself already declares Node 24 in CI/docs/runtime files.
- Full `npm audit` still reports 19 moderate dev-only findings in the Jest/Istanbul stack; `npm audit fix --force` wants a breaking `ts-jest` change, so that larger toolchain move was deferred from this sweep.

## Media evidence
- Auto-attached reviewer-facing media from the local verification artifacts captured during this run.
- This keeps the main PR body self-contained instead of relying on a follow-up comment for visual proof.

![Swagger Ui](https://res.cloudinary.com/dhwqj0ps2/image/upload/v1781576147/pr-evidence/couchbase-examples/typescript-quickstart/pr-39/swagger-ui.png)

<details><summary>Notes</summary>

- Local artifact path: `tutorial-maintenance/runs/couchbase-examples__typescript-quickstart/2026-06-16T1848PDT/screenshots/swagger-ui.png`

</details>

[Walkthrough Swagger](https://res.cloudinary.com/dhwqj0ps2/video/upload/v1781576154/pr-evidence/couchbase-examples/typescript-quickstart/pr-39/walkthrough-swagger.webm)

<details><summary>Notes</summary>

- Local artifact path: `tutorial-maintenance/runs/couchbase-examples__typescript-quickstart/2026-06-16T1848PDT/walkthrough-swagger.webm`

</details>
